### PR TITLE
Disable system,nix updates from Topgrade

### DIFF
--- a/users/alice/home.nix
+++ b/users/alice/home.nix
@@ -23,9 +23,8 @@
     # '')
 
     ncdu
-    
+
     # Rust packages
-    topgrade
     trunk
     wasm-pack
     cargo-watch
@@ -58,6 +57,13 @@
     fzf = {
       enable = true;
       enableZshIntegration = true;
+    };
+
+    topgrade = {
+      enable = true;
+      settings.config = {
+        disable = [ "system" "nix" ];
+      };
     };
   };
 


### PR DESCRIPTION
Topgrade is upgrading from local instead of remote, and throws an error when it tries to upgrade nix. Disabling these checks.