### PR TITLE
Disable podman, fix topgrade config

### DIFF
--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -27,10 +27,11 @@
       storageDriver = "overlay2";
     };
 
-    podman = {
-      enable = true;
-      recommendedDefaults = true;
-    };
+    # Disabling as topgrade apparently prefers podman over docker and now I cant update anything :(
+    # podman = {
+    #   enable = true;
+    #   recommendedDefaults = true;
+    # };
   };
 
   environment.systemPackages = with pkgs; [

--- a/users/alice/home.nix
+++ b/users/alice/home.nix
@@ -61,9 +61,9 @@
 
     topgrade = {
       enable = true;
-      settings.config = {
+      settings = {
         misc = {
-          disable = [ "system" "nix" ];
+          disable = [ "system" "nix" "shell" ];
         };
       };
     };


### PR DESCRIPTION
Adjusts settings so topgrade will work on the system as configured, unfortunately requires disabling podman as topgrade will always prefer podman over docker