### PR TITLE
Add pre-commit-update hook, make nixpkgs-fmt check only

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,11 +68,22 @@
       config = {
         repos = [
           {
+            repo = "https://gitlab.com/vojko.pribudic/pre-commit-update";
+            rev = "v0.1.2";
+            hooks = [
+              {
+                id = "pre-commit-update";
+                args = [ "--dry-run" ];
+              }
+            ];
+          }
+          {
             repo = "local";
             hooks = [
               {
-                id = "nixpkgs-fmt";
+                id = "nixpkgs-fmt check";
                 entry = "${nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt}/bin/nixpkgs-fmt";
+                args = [ "--check" ];
                 language = "system";
                 files = "\\.nix";
               }

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
         repos = [
           {
             repo = "https://gitlab.com/vojko.pribudic/pre-commit-update";
-            rev = "v0.1.2";
+            rev = "89c51188f5fb88a346d0e17773605857fce4aa42";
             hooks = [
               {
                 id = "pre-commit-update";


### PR DESCRIPTION
Run `nix-develop` to test these changes yourself. 

- Adds a hook that will always check if your remote hooks are up to date (ours are all local currently but it leaves the option open).
- Modifies `nixpkgs-fmt` hook to be check only and renamed to `nixpkgs-fmt check`. From now on if this fails the committer will need to run `nix fmt`.