### PR TITLE
Fix hydra directory

### DIFF
--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -118,7 +118,7 @@
       hydraURL = "http://localhost:3000";
       smtpHost = "alicehuston.xyz";
       notificationSender = "hydra@alicehuston.xyz";
-      gcRootsDir = "/ZFS/ZFS-Primary/hydra";
+      gcRootsDir = "/ZFS/ZFS-primary/hydra";
       useSubstitutes = true;
       minimumDiskFree = 50;
       minimumDiskFreeEvaluator = 100;


### PR DESCRIPTION
Typo in hydra gcroots means that all the nix derivations are getting stored on the SSD instead of ZFS.