### PR TITLE
fixup/redis mem

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1707978135,
-        "narHash": "sha256-Xje6vjTcVUfPg3+X4PUSlgDxA/MSqzmtjOTW47NRwwM=",
+        "lastModified": 1708150887,
+        "narHash": "sha256-lyEaeShLZqQtFO+ULLfxF9fYaYpTal0Ck1B+iKYBOMs=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "09ef6ec17141904ca28ddd62f2697f63c2aaa799",
+        "rev": "761431323e30846bae160e15682cfa687c200606",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707919853,
-        "narHash": "sha256-qxmBGDzutuJ/tsX4gp+Mr7fjxOZBbeT9ixhS5o4iFOw=",
+        "lastModified": 1708031129,
+        "narHash": "sha256-EH20hJfNnc1/ODdDVat9B7aKm0B95L3YtkIRwKLvQG8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "043ba285c6dc20f36441d48525402bcb9743c498",
+        "rev": "3d6791b3897b526c82920a2ab5f61d71985b3cf8",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707732516,
-        "narHash": "sha256-9g4yACr8OQQVbBIdU4/cIj+12oh7RTJim1KxtiNWgmI=",
+        "lastModified": 1708134366,
+        "narHash": "sha256-MtjbG+lQHrmxbBdIOlRQ9RBULsszGhqCpVD23y3KMEw=",
         "owner": "SuperSandro2000",
         "repo": "nixos-modules",
-        "rev": "043ea48acbfefea334042e9a0b84d6ba9079243f",
+        "rev": "4e41d2a44dde45e234a7795e5a502d21ad484d52",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707956935,
-        "narHash": "sha256-ZL2TrjVsiFNKOYwYQozpbvQSwvtV/3Me7Zwhmdsfyu4=",
+        "lastModified": 1708118438,
+        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4d4fe8c5002202493e87ec8dbc91335ff55552c",
+        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
         "type": "github"
       },
       "original": {
@@ -364,11 +364,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1707925466,
-        "narHash": "sha256-2xxcezb4tvssbVCU69DnTDSMB2lqwEp63JNQt8zuzcs=",
+        "lastModified": 1708018577,
+        "narHash": "sha256-B75VUqKvQeIqAUnYw4bGjY3xxrCqzRBJHLbmD0MAWEw=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "dba59970bcccfb3c6fc16ea0d0d79da875f22316",
+        "rev": "b9b0d29b8e69b02457cfabe20c4c69cdb45f3cc5",
         "type": "github"
       },
       "original": {

--- a/modules/flake-update-service.nix
+++ b/modules/flake-update-service.nix
@@ -40,9 +40,8 @@ in {
   config = lib.mkIf (cfg.enable && !(builtins.isNull cfg.path)) {
     environment.systemPackages = [ pkgs.openssh pkgs.git ];
     systemd.services."autopull@${cfg.name}" = {
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
-      requires = [ "network-online.target" ];
+      after = [ "multi-user.target" ];
+      requires = [ "multi-user.target" ];
       description = "Pull the latest data for ${cfg.name}";
       serviceConfig = {
         Type = "oneshot";

--- a/modules/flake-update-service.nix
+++ b/modules/flake-update-service.nix
@@ -42,6 +42,7 @@ in {
     systemd.services."autopull@${cfg.name}" = {
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
+      requires = [ "network-online.target" ];
       description = "Pull the latest data for ${cfg.name}";
       serviceConfig = {
         Type = "oneshot";

--- a/modules/flake-update-service.nix
+++ b/modules/flake-update-service.nix
@@ -41,7 +41,7 @@ in {
     environment.systemPackages = [ pkgs.openssh pkgs.git ];
     systemd.services."autopull@${cfg.name}" = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      after = [ "network-online.target" ];
       description = "Pull the latest data for ${cfg.name}";
       serviceConfig = {
         Type = "oneshot";

--- a/modules/flake-update-service.nix
+++ b/modules/flake-update-service.nix
@@ -43,11 +43,11 @@ in {
       after = [ "multi-user.target" ];
       requires = [ "multi-user.target" ];
       description = "Pull the latest data for ${cfg.name}";
+      environment = lib.mkIf (cfg.ssh-key != "") { GIT_SSH_COMMAND="${pkgs.openssh}/bin/ssh -i ${cfg.ssh-key} -o IdentitiesOnly=yes";};
       serviceConfig = {
         Type = "oneshot";
         User = "root";
         WorkingDirectory = cfg.path;
-        Environment = lib.mkIf (cfg.ssh-key != "") "GIT_SSH_COMMAND=${pkgs.openssh}/bin/ssh -i ${cfg.ssh-key} -o IdentitiesOnly=yes";
         ExecStart = "${pkgs.git}/bin/git pull --all";
       };
     };

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -20,6 +20,10 @@
     filesystem = "zfs";
     useSystemdBoot = true;
     kernelParams = [ "i915.force_probe=56a5" "i915.enable_guc=2" ];
+    kernel.sysctl = {
+      "vm.overcommit_memory" = 1;
+      "vm.swappiness" = 10;
+    };
   };
 
   nix = {


### PR DESCRIPTION
Fixes an issue with the autopull service where it starts way too early.

Enables the overcommit sysctl option on palatine-hill, for Redis.

This is staying a draft until I cant test the autopull fix