### PR TITLE
space optimizations

### DIFF
--- a/systems/configuration.nix
+++ b/systems/configuration.nix
@@ -188,9 +188,10 @@
       connect-timeout = 20;
     };
 
+    # free up to 10 gb when only 1 gb left
     extraOptions = ''
-      min-free = ${toString (100 * 1024 * 1024)}
-      max-free = ${toString (1024 * 1024 * 1024)}
+      min-free = ${toString (1 * 1024 * 1024 * 1024)}
+      max-free = ${toString (10 * 1024 * 1024 * 1024)}
     '';
 
     gc = {

--- a/systems/configuration.nix
+++ b/systems/configuration.nix
@@ -200,7 +200,7 @@
       options = "--delete-older-than 30d";
     };
 
-    optimize = {
+    optimise = {
       automatic = true;
       dates = [ "01:00" ];
     };

--- a/systems/configuration.nix
+++ b/systems/configuration.nix
@@ -188,10 +188,20 @@
       connect-timeout = 20;
     };
 
+    extraOptions = ''
+      min-free = ${toString (100 * 1024 * 1024)}
+      max-free = ${toString (1024 * 1024 * 1024)}
+    '';
+
     gc = {
       automatic = true;
       dates = "weekly";
       options = "--delete-older-than 30d";
+    };
+
+    optimize = {
+      automatic = true;
+      dates = [ "01:00" ];
     };
   };
 


### PR DESCRIPTION
Adds automatic hardlink optimization once every 24 hours, as well as adding a setting which will force nix to garbage collect up to 10gb of stuff whenever less than one gb is available to /nix