### PR TITLE
update alice's sops keys, as age key for jeeves changed

### DIFF
--- a/users/alice/secrets.yaml
+++ b/users/alice/secrets.yaml
@@ -6,54 +6,63 @@ sops:
     azure_kv: []
     hc_vault: []
     age:
+        - recipient: age1z8q02wdp0a2ep5uuffgfeqlfam4ztl95frhw5qhnn6knn0rrmcnqk5evej
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0bW1TYkpITFl2ckhoeUkw
+            V3NPNVUyR2JJbm9ySHN2VEFVbnM2UitIaGg4CmRkTUNMYkhIRElQMmhzd210SXV6
+            ZXVMNUtMOElrU3RZN0M1Rmw3WjFZRU0KLS0tIFRDaEU3ay9jand4ZklmNGFuQmV1
+            cDRuMTVjSXVZZWhtVytIdlhjKytwc0UKT3ndMLt6y3tReXFlUMQV8JAGc/L1ac9X
+            aYXB9IPDFxvDEF85K/0uibUR//JlFt3/M1Kc7+C+hrno9OxjYXmzfg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age128ehc0ssgwnuv4r8ayfyu7r80e82xrkmv63g7h9y9q4mhk4w9dyqfymc2w
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvNGJQMHcwbFhWb0gwOGFI
+            c0JDQkZGTjhaSU5qZnNUczY5MjF3N1hpVm44CkhSbVFHeTBYR1MyemhTSzhxUjdz
+            M25FRDJ3bERaOXNxVlU1TFRLTFV1RjQKLS0tIGc1UTFuRjJjaHNlb3ZvZUl1bXpp
+            bEZqQlhUemtQdXI5QzR1eHZKK0YrTHMKXYHCR0HOqkHrQLlksBAHDc3PzzotVkqA
+            XHFcz9fHTkYTx2Io1SWlj0vOOknDSm0RX3mGiGXlLszRaQkZi1psqg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1lffr5f5nz0nrenv3ekgy27e8sztsx4gfp3hfymkz77mqaa5a4gts0ncrrh
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1Z2VoVzlnNmZ3cUc5YStv
+            M295OXhaT3dGWnBWYThXTkJPNmxDN2tjV0RjCjlXOGhXN2JtWU0yVjI1d3V5ZnJ0
+            WjJNbkY4ZHAwY1p6TWpnR21wSmZSQ3MKLS0tIFdJZHpIbkpmUE9XamxFNkV1Q3Fa
+            RmJZNTI4S3pES0gxM1RRSHYwMDZMN0EKg9XB1Y5XEcH7xWVNYGVPvmrv1pdYQIer
+            dOznGSPPLSuoOeWFl+ZnUnGf9aP2hVOizabvtw8g+PQtLJRu9U13PA==
+            -----END AGE ENCRYPTED FILE-----
         - recipient: age1jd2dcpykagz20kpk2kkchte3augqncwfn6nywursx0dkfyze6feqdzxkq2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1Mk13QUFFeGx3OFc2MnN1
-            ejBwa25sVGJSaWhHTXI3L2dQWEk4Sm9zZ0dVCnpIblczcWRvVU02SnlNZFdvWHhy
-            d2NEMXpUUGFyUHZJeVluSEVROHV1UncKLS0tIHl0V1JaQ3ZtSkhrOXAzRkNMOU5B
-            Y0oyRWJMdXZmeDZxSzNCWUJEQzRESUkKIwxWT8Px1Y4QxW6FC349N89UbeGiA98k
-            gTwTDmABCbJt6MEc3zmoRSObirGLzgvmPjzXlHdmqcKoR0twXUBDYA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1lffr5f5nz0nrenv3ekgy27e8sztsx4gfp3hfymkz77mqaa5a4gts0ncrrh
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBra1V4bXBkZklucDEwbmdz
-            dk41QjN0eUtsZVMvellRMFRCOHd3Q2p4cXhZCmhkZzhwWTg0QkgrQTdIeEU0QjZS
-            aTU0c1NFV1hjZmFUUTFtaUYyMG1Pd2sKLS0tICtoMmsrSHJLS3g3K1JWelFOcWhL
-            VW1yekgzQkI2Uk9tRDJQTldrakZLUmMKMhmS9xqucsbfdIe1BjlPSYkvF88onzww
-            j5YkZSaaxNHcbMaTVc1+QjYv7NooM79EpUX96hP4BDwORpU3FWS2jA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1lffr5f5nz0nrenv3ekgy27e8sztsx4gfp3hfymkz77mqaa5a4gts0ncrrh
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1VHF0aUN3cE1OcUtzWkdM
-            UGNPdVJteDFvRXFXVFVTV2p0WDV1TjBrTDIwCjVpYU1vbXdDQ24vR25qN0pEalVw
-            U2laUHg4TkVCLzNQRDI5Tnpzam5ZT2MKLS0tIDJNdXk2Y3V0bEFlY0NLdXUyMWw0
-            aHZYZkJoajZDa0pZVkpxbzFXTm9ZbXMKamjLneLosXuqhUcsiLXFGEgMVN+Yzklh
-            XKf6vPmwcPuOsy5yimy5P/TygLWJ0JeXDoieDEL+/NN6kt2qtUWD4g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Yy9ZWDc4K1Q2d2cxYkoz
+            MS9yVDFRUkljVzI0ekJPMG92TU90UzVVWDA4CmtmdlVkODFaWnNQTmNCbkF5WnQy
+            TncyQWRyVFJtQzRaOGs2QVU4NWdneEUKLS0tIE5hSDZRaDlMeUtJcmxVSDFrSFd1
+            MDJhN29xZk81NG91aHFZNmpLdGRTN0EKc2pqjllcRWl3QH4BVNyylB7CMMHAH0mr
+            EsxyKrZEph7eKJYYy/9eaR1e/FvomB/1+hQXZAZVtG4bpuEG/mY14w==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-02-03T22:20:54Z"
     mac: ENC[AES256_GCM,data:X+j5RMl1RUlciT1fdLYGCzkD2AZmprmAsLhaC9Fy3zoeWlGJcC/m5g7kftPOUkha83NgOkWuaa4tjIMegQwK8snmY8R8Q6XNVuS6maYnynzFwzhGON7L33j7465onXsNqfQfa+I8AEaz69CynfbTq4L7WOLO6s8pvh1LDLi4ZvE=,iv:8uTaRrYxg6mVNIPm0Pg7S13nG2VOg/4IjVbbeilQOAg=,tag:lCrBGVRt3uYY5/fHDG2xVQ==,type:str]
     pgp:
-        - created_at: "2024-03-23T05:48:28Z"
+        - created_at: "2024-04-03T02:40:01Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA84hNUGIgI/nAQ/9HO5t//5ztagOvKoBP/W4p9Huhav4MEmqZADmbXEv+ZcG
-            ihnaeiofyoaKbJXfmGZ8vDIA68ZvKFL/n0sDR/plUHAuHuCR2qa+sVmo9ruJyKEq
-            EWc/BlguqXJCiga/MP2Ocbh+XQYJMcwGorcR1tkFjL3HkHlY+MuMCZJr8nhoERba
-            bHNIG6J31EHZ3ivub38C9GWuwaosBqO5AlUH3nRA63vMcOCwdnpXzvc4qeIgtfxn
-            ouSdj7zl75v1KG8wlR0v8ciHHdNxQ/8WoLK9QduXIFnFGxAXFYOY2838mMNZOSr4
-            q6tg7ICKdMS1h3I4cTknUFEE7ZEEDMoZR/r89rJMXMQJGZ4JWVgkAroXyriRACSp
-            GmObXzur8BmJvaSmpckacNqZqUyVCveM82344t/q4BDZmiOKUhFQNeo8uQhgd3Jf
-            Z3gnNA1FsvMJOn2/oLxDP0d54uysN1fWnuhXiosiONonBNcHCuPF5Zp3OdAXJ/a9
-            YSj0n6mee600bhn0ff0MrxXfiBQUXBnTjtUljhM1EuXrniskp1OK2Xi736O+5KwN
-            ppT0Iol/cdfUcPNj+cONjkk6xVcARNuQ8vu0clGMPfqfkg3Ne9gLqUGoH5f2PMe2
-            sWNFMhhfqcnhwEGXDw3hXEGoabzxKr5YbItwe3t9oxbp59lgxuP38yaTnOe4KzPS
-            XgHntRY2zgxeKFruk8BjCyeffJO/4uXaj2LKcGcRKP3nyJ1h0JX7itmsGbYshhTZ
-            976Oaooyoabhv7NbUrZkpk6TcD+H6AIC7vavLZsva+BgDXKRH9nxTcDXo45WbL8=
-            =qXlJ
+            hQIMA84hNUGIgI/nAQ/+J4iMzVInN/YkA0Pxgi0iMTgW/bklY2VpHofXMXXDC4Ck
+            36Y/nUoICfRJh+jFjIAWtiqcN7t9EAakTjPbobgEF1VfveUkAhR6v9mnnYW9/BNv
+            Sa9wJ9742wUEuQRTOAndyXj78z4qPSUwI29Wwe0uxKlGfrdPL5BTc9VNwCNu+WhQ
+            JD+jD/dzWAW2wxFQoJl7Zy2fChz8bkC6kEydSANPfVE4XUwFBX2Ia5bkAOjlD1JB
+            XS2ohKAuwhUQT07mj9lVnoAdhnj7gjgB0zd9xmvXVUEtIuEK7TDpBQxeaNUnU14s
+            mxJTd1ItndgdrKEtyr3QZPHz5Rsox6AuTQ3aZQVpGVXLHxL3OJ2p+fFVTrvlXfNo
+            zqqne8DDMtz4WvxTc0jaCPgYri+nbf6pb7t8dJjnva/l1qmdtzbI4d0BviSV71wk
+            Uiis6lQCoXNCwDt1loY48KdjrwKNhkzK9FBpL5sJiPmbkjrCAPjF2xEeZZpQ00rc
+            SpuOB2+JzmtqgwfXDFkQrHJRbFuhEOh6tZmv10V1pn+z6KvqZAauOCJBuXCHJ4gQ
+            OkuDXiGjRJMgg4m42AAm8XcaTkEwBZhQwaQ5C7V6l3Y2J4Bgxs/l+knM8edemmki
+            T8gVUziNR8Zw5io3AUEati5sEtw1ESi6zvXmyoStTikk6T68Zb8yWOBiX9h+YPjS
+            XgHhVuu+ynwsRV9S/Q+m7hsW3tls7aIpomOk6ah8G4phs6ecc46W2MLvcFk1JGmi
+            /E/Y4D/u/HSBBs+ETJCd8kXOfu3J3Ivu2vAxKWSng39eJ5UZCBS9GOnrO0xb1WY=
+            =w29N
             -----END PGP MESSAGE-----
           fp: F63832C3080D6E1AC77EECF80B4245FFE305BC82
     unencrypted_suffix: _unencrypted


### PR DESCRIPTION
jeeves is having an issue pulling updates as the age key changed.. i checked the nix store path on palatine-hill and its pointing at my secrets file which apparently needed an `sops updatekeys`.

I think the main reason `nixos-rebuild` was failing was due to the flake config changes (either cache or substitutors i'm not sure), which is expected and normally remediated when the next manually invoked upgrade is triggered. I ran a manual update off the main branch and it seems to be working but this sops fix should close out any other potential failures.

affected nix store path:
/nix/store/fjjxfa1671g9rxnh9wih2p702pgwrqna-secrets.yaml

jeeves updates:
![image](https://github.com/RAD-Development/nix-dotfiles/assets/43225907/984a105d-c0ee-4c45-a0ba-42afdff07e4d)

updatekeys:
![image](https://github.com/RAD-Development/nix-dotfiles/assets/43225907/e77f6f74-f15d-4a94-a91f-59918927354f)
