### PR TITLE
switch to nixos-unstable-small, which already finished the xz revert

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -281,16 +281,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1712047400,
+        "narHash": "sha256-P1ddj7Anx1zQXyn1RqLcleA3ZL/8cmewWjdm2nR7mc8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "43f956227e7bbcb11aa54ce1294f6b5bdf6c8fad",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-23.11";
     systems.url = "github:nix-systems/default";
     nix-index-database = {
@@ -147,9 +147,9 @@
         }
       );
 
-      src =
-        builtins.filterSource (path: type: type == "directory" || lib.hasSuffix ".nix" (baseNameOf path))
-          ./.;
+      src = builtins.filterSource (
+        path: type: type == "directory" || lib.hasSuffix ".nix" (baseNameOf path)
+      ) ./.;
       ls = dir: lib.attrNames (builtins.readDir (src + "/${dir}"));
       lsdir =
         dir:
@@ -258,12 +258,8 @@
                 ++ fileList "modules"
                 ++ modules
                 ++ lib.optional home home-manager.nixosModules.home-manager
-                ++
-                  lib.optional (builtins.elem "minimal" iso)
-                    "${toString nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
-                ++
-                  lib.optional (builtins.elem "sd" iso)
-                    "${toString nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+                ++ lib.optional (builtins.elem "minimal" iso) "${toString nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+                ++ lib.optional (builtins.elem "sd" iso) "${toString nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
                 ++ (
                   if home then
                     (map (user: { home-manager.users.${user} = import ./users/${user}/home.nix; }) users)
@@ -276,123 +272,106 @@
                     buildPlatform = "x86_64-linux";
                   };
                 }
-                ++
-                  map
-                    (
-                      user:
-                      {
-                        config,
-                        lib,
-                        pkgs,
-                        ...
-                      }@args:
-                      {
-                        users.users.${user} = import ./users/${user} (args // { name = "${user}"; });
-                        boot.initrd.network.ssh.authorizedKeys =
-                          lib.mkIf server
-                            config.users.users.${user}.openssh.authorizedKeys.keys;
-                        sops = lib.mkIf sops {
-                          secrets."${user}/user-password" = {
-                            sopsFile = ./users/${user}/secrets.yaml;
-                            neededForUsers = true;
-                          };
-                        };
-                      }
-                    )
-                    users;
+                ++ map (
+                  user:
+                  {
+                    config,
+                    lib,
+                    pkgs,
+                    ...
+                  }@args:
+                  {
+                    users.users.${user} = import ./users/${user} (args // { name = "${user}"; });
+                    boot.initrd.network.ssh.authorizedKeys =
+                      lib.mkIf server
+                        config.users.users.${user}.openssh.authorizedKeys.keys;
+                    sops = lib.mkIf sops {
+                      secrets."${user}/user-password" = {
+                        sopsFile = ./users/${user}/secrets.yaml;
+                        neededForUsers = true;
+                      };
+                    };
+                  }
+                ) users;
             };
         in
         (builtins.listToAttrs (
-          map
-            (system: {
-              name = system;
+          map (system: {
+            name = system;
+            value = constructSystem (
+              {
+                hostname = system;
+              }
+              // builtins.removeAttrs (import ./systems/${system} { inherit inputs; }) [
+                "hostname"
+                "server"
+                "home"
+              ]
+            );
+          }) (lsdir "systems")
+        ))
+        // (builtins.listToAttrs (
+          builtins.concatMap (
+            user:
+            map (system: {
+              name = "${user}.${system}";
               value = constructSystem (
                 {
                   hostname = system;
+                  server = false;
+                  users = [ user ];
                 }
-                // builtins.removeAttrs (import ./systems/${system} { inherit inputs; }) [
+                // builtins.removeAttrs (import ./users/${user}/systems/${system} { inherit inputs; }) [
                   "hostname"
                   "server"
-                  "home"
+                  "users"
                 ]
               );
-            })
-            (lsdir "systems")
-        ))
-        // (builtins.listToAttrs (
-          builtins.concatMap
-            (
-              user:
-              map
-                (system: {
-                  name = "${user}.${system}";
-                  value = constructSystem (
-                    {
-                      hostname = system;
-                      server = false;
-                      users = [ user ];
-                    }
-                    // builtins.removeAttrs (import ./users/${user}/systems/${system} { inherit inputs; }) [
-                      "hostname"
-                      "server"
-                      "users"
-                    ]
-                  );
-                })
-                (lsdir "users/${user}/systems")
-            )
-            (lsdir "users")
+            }) (lsdir "users/${user}/systems")
+          ) (lsdir "users")
         ));
 
-      devShell =
-        lib.mapAttrs
-          (
-            system: sopsPkgs:
-            with nixpkgs.legacyPackages.${system};
-            mkShell {
-              sopsPGPKeyDirs = [ "./keys" ];
-              nativeBuildInputs = [
-                apacheHttpd
-                sopsPkgs.sops-import-keys-hook
-              ];
-              packages = [
-                self.formatter.${system}
-                nixpkgs.legacyPackages.${system}.deadnix
-              ];
-              shellHook = (nix-pre-commit.lib.${system}.mkConfig { inherit pkgs config; }).shellHook;
-            }
-          )
-          sops-nix.packages;
+      devShell = lib.mapAttrs (
+        system: sopsPkgs:
+        with nixpkgs.legacyPackages.${system};
+        mkShell {
+          sopsPGPKeyDirs = [ "./keys" ];
+          nativeBuildInputs = [
+            apacheHttpd
+            sopsPkgs.sops-import-keys-hook
+          ];
+          packages = [
+            self.formatter.${system}
+            nixpkgs.legacyPackages.${system}.deadnix
+          ];
+          shellHook = (nix-pre-commit.lib.${system}.mkConfig { inherit pkgs config; }).shellHook;
+        }
+      ) sops-nix.packages;
 
       hydraJobs =
         {
           build = (
             recursiveMerge (
-              (map
-                (machine: {
-                  ${machine.pkgs.system} = (
-                    builtins.listToAttrs (
-                      builtins.filter (v: v != { }) (
-                        map
-                          (
-                            pkg:
-                            (
-                              if (builtins.hasAttr pkg.name pkgsBySystem.${machine.pkgs.system}) then
-                                {
-                                  name = pkg.name;
-                                  value = pkgsBySystem.${machine.pkgs.system}.${pkg.name};
-                                }
-                              else
-                                { }
-                            )
-                          )
-                          machine.config.environment.systemPackages
-                      )
+              (map (machine: {
+                ${machine.pkgs.system} = (
+                  builtins.listToAttrs (
+                    builtins.filter (v: v != { }) (
+                      map (
+                        pkg:
+                        (
+                          if (builtins.hasAttr pkg.name pkgsBySystem.${machine.pkgs.system}) then
+                            {
+                              name = pkg.name;
+                              value = pkgsBySystem.${machine.pkgs.system}.${pkg.name};
+                            }
+                          else
+                            { }
+                        )
+                      ) machine.config.environment.systemPackages
                     )
-                  );
-                })
-                (builtins.attrValues self.nixosConfigurations)
-              )
+                  )
+                );
+              }) (builtins.attrValues self.nixosConfigurations))
               ++ [
                 # not fully sure what this is for but it breaks with nixfmt
                 # (forEachSystem (system: {

--- a/users/alice/systems/artemision/configuration.nix
+++ b/users/alice/systems/artemision/configuration.nix
@@ -49,13 +49,10 @@
   sops.age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
 
   services.fwupd.package =
-    (import
-      (builtins.fetchTarball {
-        url = "https://github.com/NixOS/nixpkgs/archive/bb2009ca185d97813e75736c2b8d1d8bb81bde05.tar.gz";
-        sha256 = "sha256:003qcrsq5g5lggfrpq31gcvj82lb065xvr7bpfa8ddsw8x4dnysk";
-      })
-      { inherit (pkgs) system; }
-    ).fwupd;
+    (import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/bb2009ca185d97813e75736c2b8d1d8bb81bde05.tar.gz";
+      sha256 = "sha256:003qcrsq5g5lggfrpq31gcvj82lb065xvr7bpfa8ddsw8x4dnysk";
+    }) { inherit (pkgs) system; }).fwupd;
 
   services.fprintd.enable = false;
 


### PR DESCRIPTION
xz rebuild requires bootstrapping the toolchain, and rebuilds something stupid like 5,000 packages in total. given the sheer scale, apparently that's around 10 days worth of compute on the nixpkgs hydra cluster and the reverted package won't be available in nixos-unstable for probably 6-8 more days. Its likely that nixos isn't directly impacted as the specific payload was looking for debian and rpm specific files and variables (and relies on a patch which nixos didn't include), but out of an abundance of caution, we should probably flip over to nixos-unstable-small.

since nixos-unstable-small is geared towards servers and has a reduced closure size, there is a chance we're gonna be building GUI apps more often. The increased build cost on main can be redirected to the hydra instance we can investigate making palatine-hill (or maybe just hydra?) a remote builder.

https://nixpk.gs/pr-tracker.html?pr=300028