### PR TITLE
Feature/hydra ssh ng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ result
 result-*
 
 # If you run nix develop it will generate pre-commit hooks using the python library precommit (see https://github.com/RAD-Development/nix-dotfiles/blob/main/flake.nix#L65)
-/.pre-commit-config.yaml
+.pre-commit-config.yaml
 
 # allows test file in reopsitory
 test.*

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -227,6 +227,14 @@ in
     };
   };
 
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ/E/y4UJQid6/0D9babh8l/3jTDJRXqZQ5rPcoxwm1j root@palatine-hill"
+  ];
+
+  users.users.hydra-queue-runner.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHtwvfXg/QFjMAjC4JRjlMAaGPgEfSyhpprNpqbGSJn hydra-queue-runner@palatine-hill"
+  ];
+
   sops = {
     defaultSopsFile = ./secrets.yaml;
     secrets =

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -64,6 +64,7 @@ in
         ];
       }
     ];
+    distributedBuilds = true;
   };
 
   hardware = {

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -232,6 +232,7 @@ in
   ];
 
   users.users.hydra-queue-runner.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ/E/y4UJQid6/0D9babh8l/3jTDJRXqZQ5rPcoxwm1j root@palatine-hill"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHtwvfXg/QFjMAjC4JRjlMAaGPgEfSyhpprNpqbGSJn hydra-queue-runner@palatine-hill"
   ];
 

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 let
   keygen = key: {
     "${key}" = {
@@ -54,6 +59,7 @@ in
         systems = [
           "x86_64-linux"
           "aarch64-linux"
+          "i686-linux"
         ];
 
         supportedFeatures = [
@@ -64,7 +70,6 @@ in
         ];
       }
     ];
-    distributedBuilds = true;
   };
 
   hardware = {
@@ -160,6 +165,7 @@ in
       notificationSender = "hydra@alicehuston.xyz";
       gcRootsDir = "/ZFS/ZFS-primary/hydra";
       useSubstitutes = true;
+      buildMachinesFiles = [ ];
       minimumDiskFree = 50;
       minimumDiskFreeEvaluator = 100;
     };

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -12,4 +12,3 @@ command = "nixfmt"
 #options = []
 # Glob pattern of files to include
 includes = [ "*.nix" ]
-


### PR DESCRIPTION
Semi-urgent fix for hydra. 

Hydra appears to fail all connections with `failed to connect to ssh-ng://localhost` with the current config. I was not able to isolate which commit this came from but when disabling ssh-ng I got a bit more detail. It looks like it was trying to invoke `nix-serve --serve --write --builders` where builders needs an argument. I set the builders to `[ ]` for now as we're only running one builder and the empty set should invoke the localhost builder anyway. will monitor for any further issues and put in another PR if needed.