### PR TITLE
does flake updates every day at noon

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -3,7 +3,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "51 2 * * 1,4"
+    - cron: "00 12 * * *"
 jobs:
   createPullRequest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since we have Hydra set up now for the flake update branch, this will let us see if we can upgrade safely, as well as pushing more artifacts into the cache.