### PR TITLE
override nerdfonts for artemision

### DIFF
--- a/users/alice/systems/artemision/fonts.nix
+++ b/users/alice/systems/artemision/fonts.nix
@@ -3,6 +3,17 @@
   fonts = {
     fontconfig.enable = true;
     enableDefaultPackages = true;
-    packages = with pkgs; [ nerdfonts ];
+    packages = with pkgs; [
+      (nerdfonts.override {
+        fonts = [
+          "FiraCode"
+          "DroidSansMono"
+          "Hack"
+          "DejaVuSansMono"
+          "Noto"
+          "OpenDyslexic"
+        ];
+      })
+    ];
   };
 }


### PR DESCRIPTION
restricts the font list to a subset of nerdfonts