### PR TITLE
Feature/nix store migration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,14 @@
   nixConfig = {
     substituters = [
       "https://cache.nixos.org/?priority=1&want-mass-query=true"
-      "https://attic.alicehuston.xyz/cache-nix-dot?priority=4&want-mass-query=true"
-      "https://cache.alicehuston.xyz/?priority=5&want-mass-query=true"
+      # "https://attic.alicehuston.xyz/cache-nix-dot?priority=4&want-mass-query=true"
+      # "https://cache.alicehuston.xyz/?priority=5&want-mass-query=true"
       "https://nix-community.cachix.org/?priority=10&want-mass-query=true"
     ];
     trusted-substituters = [
       "https://cache.nixos.org"
-      "https://attic.alicehuston.xyz/cache-nix-dot"
-      "https://cache.alicehuston.xyz"
+      # "https://attic.alicehuston.xyz/cache-nix-dot"
+      # "https://cache.alicehuston.xyz"
       "https://nix-community.cachix.org"
     ];
     trusted-public-keys = [

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,14 @@
   nixConfig = {
     substituters = [
       "https://cache.nixos.org/?priority=1&want-mass-query=true"
-      # "https://attic.alicehuston.xyz/cache-nix-dot?priority=4&want-mass-query=true"
-      # "https://cache.alicehuston.xyz/?priority=5&want-mass-query=true"
+      "https://attic.alicehuston.xyz/cache-nix-dot?priority=4&want-mass-query=true"
+      "https://cache.alicehuston.xyz/?priority=5&want-mass-query=true"
       "https://nix-community.cachix.org/?priority=10&want-mass-query=true"
     ];
     trusted-substituters = [
       "https://cache.nixos.org"
-      # "https://attic.alicehuston.xyz/cache-nix-dot"
-      # "https://cache.alicehuston.xyz"
+      "https://attic.alicehuston.xyz/cache-nix-dot"
+      "https://cache.alicehuston.xyz"
       "https://nix-community.cachix.org"
     ];
     trusted-public-keys = [

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -257,7 +257,9 @@ in
 
   nix.gc.options = "--delete-older-than 150d";
 
-  # TODO: revert this before merging
+  # TODO: revert this once UPS is plugged in
+  # Not reverting this before the merge as the UPS not being plugged in is
+  # causing upgrades to fail
   power.ups = {
     enable = false;
     ups."LX1325GU3" = {

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -257,8 +257,9 @@ in
 
   nix.gc.options = "--delete-older-than 150d";
 
+  # TODO: revert this before merging
   power.ups = {
-    enable = true;
+    enable = false;
     ups."LX1325GU3" = {
       driver = "usbhid-ups";
       port = "auto";

--- a/systems/palatine-hill/hardware.nix
+++ b/systems/palatine-hill/hardware.nix
@@ -42,6 +42,8 @@
       device = "ZFS-primary/nix";
       fsType = "zfs";
       depends = [ "/crypto/keys" ];
+      neededForBoot = true;
+      options = [ "noatime" ];
     };
   };
 }

--- a/systems/palatine-hill/hardware.nix
+++ b/systems/palatine-hill/hardware.nix
@@ -38,5 +38,10 @@
       device = "/dev/disk/by-uuid/4CBA-2451";
       fsType = "vfat";
     };
+    "/nix" = {
+      device = "ZFS-primary/nix";
+      fsType = "zfs";
+      depends = [ "/crypto/keys" ];
+    };
   };
 }


### PR DESCRIPTION
Migrate `/nix` on palatine-hill to ZFS.

Notes, for this to work `mountpoint=legacy` must be set for the dataset. The migration actually ended up being done live per [these steps](https://nixos.wiki/wiki/Storage_optimization#Moving_the_store) and hard-linking does not work at all during the rsync process (`nix-store --optimise` should be run after the migration if hard-linking is being used).