### PR TITLE
Feature/direnv integration

### DIFF
--- a/users/alice/home.nix
+++ b/users/alice/home.nix
@@ -107,6 +107,11 @@
       enable = true;
       enableZshIntegration = true;
     };
+    direnv = {
+      enable = true;
+      enableZshIntegration = true;
+      nix-direnv.enable = true;
+    };
 
     neovim = {
       enable = true;

--- a/users/alice/home.nix
+++ b/users/alice/home.nix
@@ -45,7 +45,6 @@
       neofetch
       smartmontools
       wget
-      zsh-nix-shell
       glances
 
       # Rust packages

--- a/users/alice/home/zsh.nix
+++ b/users/alice/home/zsh.nix
@@ -17,25 +17,8 @@
         "tmux"
         "ufw"
         "z"
-        #"fzf"
       ];
     };
-    zplug = {
-      enable = true;
-      plugins = [ { name = "chisui/zsh-nix-shell"; } ];
-    };
-    # plugins = [
-    #   {
-    #     name = "zsh-nix-shell";
-    #     file = "nix-shell.plugin.zsh";
-    #     src = pkgs.fetchFromGitHub {
-    #       owner = "chisui";
-    #       repo = "zsh-nix-shell";
-    #       rev = "v0.8.0";
-    #       sha256 = "1lzrn0n4fxfcgg65v0qhnj7wnybybqzs4adz7xsrkgmcsr0ii8b7";
-    #     };
-    #   }
-    # ];
     initExtra = ''
       # functions
       function mount-data {


### PR DESCRIPTION
i thought i made this PR but apparently not.

This change puts you in a nix shell automatically as long as direnv is set up for the repo (which is already done in `.envrc`

![image](https://github.com/RAD-Development/nix-dotfiles/assets/43225907/5bbf689b-2fac-4449-bef3-35029b0b9927)

@RichieCahill feel free to add your changes here.