### PR TITLE
Feature/wakatime

### DIFF
--- a/users/alice/home.nix
+++ b/users/alice/home.nix
@@ -87,6 +87,7 @@
       rust-analyzer
       clang
       clang-tools
+      wakatime
 
       # audit
       lynis


### PR DESCRIPTION
Fixes wakatime for emacs on alice's machines, requires #182 as that fixes sops-nix/home-manager integration