### PR TITLE
Home-manager server/non-server config option

### DIFF
--- a/lib/systems.nix
+++ b/lib/systems.nix
@@ -159,7 +159,9 @@ rec {
     }@args:
     lib.nixosSystem {
       inherit system;
-      specialArgs = inputs;
+      specialArgs = {
+        inherit inputs server;
+      };
       modules =
         [
           inputs.nixos-modules.nixosModule

--- a/lib/systems.nix
+++ b/lib/systems.nix
@@ -153,7 +153,7 @@ rec {
       users,
       home ? true,
       modules ? [ ],
-      # server ? true,
+      server ? true,
       sops ? true,
       system ? "x86_64-linux",
     }@args:

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -1,4 +1,9 @@
-{ lib, sops-nix, ... }:
+{
+  lib,
+  inputs,
+  server,
+  ...
+}:
 {
   boot.default = lib.mkDefault true;
 
@@ -18,6 +23,11 @@
   home-manager = {
     useGlobalPkgs = true;
     useUserPackages = true;
-    sharedModules = [ sops-nix.homeManagerModules.sops ];
+    sharedModules = [ inputs.sops-nix.homeManagerModules.sops ];
+    extraSpecialArgs = {
+      machineConfig = {
+        inherit server;
+      };
+    };
   };
 }

--- a/systems/artemision/default.nix
+++ b/systems/artemision/default.nix
@@ -3,6 +3,7 @@
   system = "x86_64-linux";
   home = true;
   sops = true;
+  server = false;
   users = [ "alice" ];
   modules = [
     inputs.nixos-hardware.nixosModules.framework-16-7040-amd

--- a/systems/rhapsody-in-green/default.nix
+++ b/systems/rhapsody-in-green/default.nix
@@ -4,5 +4,6 @@
   system = "x86_64-linux";
   home = true;
   sops = true;
+  server = false;
   modules = [ inputs.nixos-hardware.nixosModules.framework-13-7040-amd ];
 }

--- a/users/alice/home.nix
+++ b/users/alice/home.nix
@@ -1,4 +1,10 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  machineConfig,
+  ...
+}:
 
 {
   imports = [
@@ -6,7 +12,7 @@
     ./home/doom
     ./home/gammastep.nix
     ./home/git.nix
-  ];
+  ] ++ lib.optionals (!machineConfig.server) [ ./non-server.nix ];
 
   home = {
     # # Adds the 'hello' command to your environment. It prints a friendly
@@ -100,10 +106,6 @@
   };
 
   programs = {
-    emacs = {
-      enable = true;
-      package = pkgs.emacs29-pgtk;
-    };
 
     starship.enable = true;
     fzf = {

--- a/users/alice/non-server.nix
+++ b/users/alice/non-server.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  programs.emacs = {
+    enable = true;
+    package = pkgs.emacs29-pgtk;
+  };
+}


### PR DESCRIPTION
Depends on #188 being merged

## Changelog

- passes a new `machineConfig` option to home-manager, which currently only contains the `server` boolean attribute, although can be expanded to support any attribute which is passed to the system via a change in `modules/base.nix` and `lib/systems.nix`.
- Sets up artemision and rhapsody-in-green as explicity `server = false`
- Moves some of the artemision config to the new `users/alice/non-server.nix`, which is imported to the primary config using `lib.optionals` and `machineConfig.server`