### PR TITLE
plocate per-user file visibility

### DIFF
--- a/users/default.nix
+++ b/users/default.nix
@@ -20,6 +20,7 @@
     (lib.mkIf config.programs.adb.enable "adbusers")
     (lib.mkIf config.programs.wireshark.enable "wireshark")
     (lib.mkIf config.virtualisation.docker.enable "docker")
+    (lib.mkIf (with config.services.locate; (enable && package == pkgs.plocate)) "plocate")
     "libvirtd"
     "dialout"
     "plugdev"


### PR DESCRIPTION
as per the debian man pages, there is a default option for `plocate` [-l, --require-visibility FLAG](https://manpages.debian.org/unstable/plocate/updatedb.plocate.8.en.html#l). Basically, the user only gets access to the plocate database if it has the `plocate` group and then the files are only visible if the user has access to all parent folders. See an example below with a test file.

folder creation (owned by root/root, 755 perms)
![image](https://github.com/RAD-Development/nix-dotfiles/assets/43225907/cdd8b799-ef1b-4d14-ba3f-68d46908908e)

initial plocate results, file is visible as parent folder `plocatetestfolder/` has execute perms
![image](https://github.com/RAD-Development/nix-dotfiles/assets/43225907/11c3e6fb-885d-4a0f-b932-38b9583be424)

`plocatetestfolder/` is visible as `nix-dotfiles` folder is visible, but `plocatetestfolder/plocatetestfile` isn't visible as the exec permission isn't set on the parent folder
![image](https://github.com/RAD-Development/nix-dotfiles/assets/43225907/578db61c-7cd6-4f67-a87c-97784a94ea90)
