### PR TITLE
fixes localuser warning due to plocate incompatibility

### DIFF
--- a/modules/plocate.nix
+++ b/modules/plocate.nix
@@ -3,6 +3,7 @@
 {
   services.locate = {
     enable = lib.mkDefault true;
+    localuser = lib.mkDefault null;
     package = lib.mkDefault pkgs.plocate;
   };
 }


### PR DESCRIPTION
Fixes this warning:

`trace: warning: mlocate and plocate do not support the services.locate.localuser option. updatedb will run as root. Silence this warning by setting services.locate.localuser = null.`