### PR TITLE
Image generation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -267,6 +267,42 @@
         "type": "github"
       }
     },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1712450863,
+        "narHash": "sha256-K6IkdtMtq9xktmYPj0uaYc8NsIqHuaAoRBaMgu9Fvrw=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "3c62b6a12571c9a7f65ab037173ee153d539905f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixos-generators": {
+      "inputs": {
+        "nixlib": "nixlib",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716210724,
+        "narHash": "sha256-iqQa3omRcHGpWb1ds75jS9ruA5R39FTmAkeR3J+ve1w=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "d14b286322c7f4f897ca4b1726ce38cb68596c94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "type": "github"
+      }
+    },
     "nixos-hardware": {
       "locked": {
         "lastModified": 1717248095,
@@ -403,6 +439,7 @@
         "hyprland-contrib": "hyprland-contrib",
         "nix": "nix",
         "nix-index-database": "nix-index-database",
+        "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
         "nixos-modules": "nixos-modules",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,10 @@
       url = "github:Mic92/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nixos-generators = {
+      url = "github:nix-community/nixos-generators";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     nixos-modules = {
       url = "github:SuperSandro2000/nixos-modules";

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,7 @@
           lib = self;
         }
       );
-      inherit (lib.rad-dev.systems) genSystems;
+      inherit (lib.rad-dev.systems) genSystems getImages;
       inherit (self) outputs; # for hydra
     in
     rec {
@@ -154,6 +154,12 @@
       formatter = forEachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
 
       nixosConfigurations = genSystems inputs src (src + "/systems");
+      images = {
+        install-iso = getImages nixosConfigurations "install-iso";
+        iso = getImages nixosConfigurations "iso";
+        qcow = getImages nixosConfigurations "qcow";
+      };
+
       checks = import ./checks.nix { inherit inputs forEachSystem formatter; };
       devShells = import ./shell.nix { inherit inputs forEachSystem checks; };
     };

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -3,10 +3,10 @@ let
   inherit (inputs.nixpkgs.lib) mapAttrs;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
-  getFormat =
-    _: cfg: format:
-    cfg.config.formats.${format};
-  imageWrapper = format: mapAttrs getFormat outputs.nixosConfigurations format;
+  # getFormat =
+  #   _: cfg: format:
+  #    cfg.config.formats.${format};
+  imageWrapper = format: mapAttrs (_: cfg: cfg.config.formats.${format}) outputs.nixosConfigurations;
 in
 {
   inherit (outputs) formatter devShells;

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -3,8 +3,15 @@ let
   inherit (inputs.nixpkgs.lib) mapAttrs;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
+  getFormat =
+    _: cfg: format:
+    cfg.config.formats.${format};
+  imageWrapper = format: mapAttrs getFormat outputs.nixosConfigurations format;
 in
 {
   inherit (outputs) formatter devShells;
   hosts = mapAttrs getCfg outputs.nixosConfigurations;
+  install-isos = imageWrapper "install-iso";
+  isos = imageWrapper "iso";
+  qcow = imageWrapper "qcow";
 }

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -3,15 +3,8 @@ let
   inherit (inputs.nixpkgs.lib) mapAttrs;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
-  # getFormat =
-  #   _: cfg: format:
-  #    cfg.config.formats.${format};
-  imageWrapper = format: mapAttrs (_: cfg: cfg.config.formats.${format}) outputs.nixosConfigurations;
 in
 {
   inherit (outputs) formatter devShells;
   hosts = mapAttrs getCfg outputs.nixosConfigurations;
-  install-isos = imageWrapper "install-iso";
-  isos = imageWrapper "iso";
-  qcow = imageWrapper "qcow";
 }

--- a/lib/systems.nix
+++ b/lib/systems.nix
@@ -213,4 +213,15 @@ rec {
         }
       ) (lib.rad-dev.lsdir path)
     );
+
+  # gets all the images of a specified format
+  #
+  # args:
+  # systems: a set of systems to generate (usually outputs.nixosConfigurations)
+  # format: a format to generate images for (must be a format compatible with
+  #         nixos-generators or custom)
+  #
+  # type:
+  # AttrSet -> String -> AttrSet
+  getImages = systems: format: lib.mapAttrs (_: cfg: cfg.config.formats.${format}) systems;
 }

--- a/modules/generators.nix
+++ b/modules/generators.nix
@@ -1,0 +1,11 @@
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+
+{
+  imports = [ inputs.nixos-generators.nixosModules.all-formats ];
+}

--- a/modules/openssh.nix
+++ b/modules/openssh.nix
@@ -33,7 +33,7 @@
       MaxSessions = lib.mkDefault 2;
       PasswordAuthentication = false;
       PermitEmptyPasswords = "no";
-      PermitRootLogin = "no";
+      PermitRootLogin = lib.mkForce "no";
       TcpKeepAlive = "no";
       X11Forwarding = lib.mkDefault false;
       KexAlgorithms = [

--- a/systems/artemision/configuration.nix
+++ b/systems/artemision/configuration.nix
@@ -50,7 +50,7 @@
       }) { inherit (pkgs) system; }).fwupd;
 
     fprintd.enable = true;
-    openssh.enable = lib.mkDefault false;
+    openssh.enable = lib.mkForce false;
 
     spotifyd = {
       enable = true;

--- a/systems/artemision/configuration.nix
+++ b/systems/artemision/configuration.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   imports = [
     ./programs.nix
@@ -45,7 +50,7 @@
       }) { inherit (pkgs) system; }).fwupd;
 
     fprintd.enable = true;
-    openssh.enable = false;
+    openssh.enable = lib.mkDefault false;
 
     spotifyd = {
       enable = true;

--- a/systems/artemision/hardware.nix
+++ b/systems/artemision/hardware.nix
@@ -46,7 +46,7 @@
 
   fileSystems = {
 
-    "/" = {
+    "/" = lib.mkDefault {
       device = "/dev/disk/by-uuid/f3c11d62-37f4-495e-b668-1ff49e0d3a47";
       fsType = "ext4";
       options = [

--- a/systems/jeeves-jr/hardware.nix
+++ b/systems/jeeves-jr/hardware.nix
@@ -28,7 +28,7 @@
   };
 
   fileSystems = {
-    "/" = {
+    "/" = lib.mkDefault {
       device = "/dev/disk/by-uuid/c59f7261-ebab-4cc9-8f1d-3f4c2e4b1971";
       fsType = "ext4";
     };

--- a/systems/jeeves/hardware.nix
+++ b/systems/jeeves/hardware.nix
@@ -28,7 +28,7 @@
     extraModulePackages = [ ];
   };
 
-  fileSystems."/" = {
+  fileSystems."/" = lib.mkDefault {
     device = "/dev/disk/by-uuid/0f78fa87-30be-4173-b0fa-eaa956cf83aa";
     fsType = "ext4";
   };

--- a/systems/palatine-hill/configuration.nix
+++ b/systems/palatine-hill/configuration.nix
@@ -43,7 +43,7 @@ in
       "i915.enable_guc=2"
     ];
     kernel.sysctl = {
-      "vm.overcommit_memory" = 1;
+      "vm.overcommit_memory" = lib.mkForce 1;
       "vm.swappiness" = 10;
     };
     extraModprobeConfig = ''

--- a/systems/palatine-hill/hardware.nix
+++ b/systems/palatine-hill/hardware.nix
@@ -28,7 +28,7 @@
   };
 
   fileSystems = {
-    "/" = {
+    "/" = lib.mkDefault {
       device = "/dev/disk/by-uuid/b3b709ce-fe88-4267-be47-bf991a512cbe";
       fsType = "ext4";
     };

--- a/systems/rhapsody-in-green/hardware.nix
+++ b/systems/rhapsody-in-green/hardware.nix
@@ -24,7 +24,7 @@
     extraModulePackages = [ ];
   };
 
-  fileSystems."/" = {
+  fileSystems."/" = lib.mkDefault {
     device = "/dev/disk/by-uuid/c5cc486b-0076-40b0-9402-7ddb2b4a7fdf";
     fsType = "ext4";
   };


### PR DESCRIPTION
Adds `iso`, `install-iso`, and `qcow` generation for all machines via `nix build .#images.<format>.<hostname>`, and fixes (most of) the issues that were blocking image generation except for the one error below. 

I **very** briefly added this to Hydra, but the act of fixing an issue and pushing again like 2-4 times has caused the nix-store to explode and atticd to run out of memory. So yeah we're doing this one by request only.

Note: the `images.<format>` output is very much a convenience function. Any format can be build using the same logic as `lib.rad-dev.getImages` which is to say `nix build .#nixosConfigurations.<system>.config.formats.<format>` should do the same thing for any format available in [nixos-generators](https://github.com/nix-community/nixos-generators).

```
in job ‘install-isos.rhapsody-in-green’:
error:
       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:19:19:
           18|       value = commonAttrs // {
           19|         outPath = builtins.getAttr outputName strict;
             |                   ^
           20|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:9:12:
            8|
            9|   strict = derivationStrict drvAttrs;
             |            ^
           10|

       (stack trace truncated; use '--show-trace' to show the full trace)

       error:
       Failed assertions:
       - You can not use networking.networkmanager with networking.wireless.
       Except if you mark some interfaces as <literal>unmanaged</literal> by NetworkManager.
```
</details>