### PR TITLE
remove cache.alicehuston.xyz

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,13 +5,11 @@
     substituters = [
       "https://cache.nixos.org/?priority=1&want-mass-query=true"
       "https://attic.alicehuston.xyz/cache-nix-dot?priority=4&want-mass-query=true"
-      "https://cache.alicehuston.xyz/?priority=5&want-mass-query=true"
       "https://nix-community.cachix.org/?priority=10&want-mass-query=true"
     ];
     trusted-substituters = [
       "https://cache.nixos.org"
       "https://attic.alicehuston.xyz/cache-nix-dot"
-      "https://cache.alicehuston.xyz"
       "https://nix-community.cachix.org"
     ];
     trusted-public-keys = [


### PR DESCRIPTION
Removes `cache.alicehuston.xyz` from the flake (meaning only the faster downloads via attic will be done). This means that there's more stuff that the users are going to have to build from source, but the downloads are going to be significantly smaller.