### PR TITLE
remove pynose from user config

### DIFF
--- a/users/alice/non-server.nix
+++ b/users/alice/non-server.nix
@@ -11,7 +11,6 @@
     glslang
     pipenv
     python312Packages.isort
-    python312Packages.pynose
     python312Packages.pytest
 
     # rust tools


### PR DESCRIPTION
user config change only, removes pynose due to the below license violation

```shell       
error: pynose was removed, because it violates the license of nose, by redistributing modified LGPL code under MIT.
```