### PR TITLE
temporarily remove playonlinux from artemision

### DIFF
--- a/systems/artemision/programs.nix
+++ b/systems/artemision/programs.nix
@@ -55,7 +55,8 @@
     nmap
     ocrmypdf
     pciutils
-    playonlinux
+    #disabled until wxpython compat with python3.12
+    #playonlinux
     prismlauncher
     protonmail-bridge
     protontricks


### PR DESCRIPTION
Until the wxpython compat PR is merged (nixpkgs PR 326142), disabling playonlinux so we can update finally hopefully

Proof that the update builds:
![image](https://github.com/user-attachments/assets/1c329c68-e13c-480d-b120-5dc3bc0eca7b)
