### PR TITLE
Add aggregate checks, add Hydra feedback to GitHub

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,7 @@
     rec {
       inherit lib; # for allowing use of custom functions in nix repl
 
-      hydraJobs = import ./hydra/jobs.nix { inherit inputs outputs; };
+      hydraJobs = import ./hydra/jobs.nix { inherit inputs outputs systems; };
       formatter = forEachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
 
       nixosConfigurations = genSystems inputs src (src + "/systems");

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -5,10 +5,13 @@ let
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
 in
-{
+rec {
   inherit (outputs) formatter devShells checks;
+
+  machines = mapAttrsToList getCfg outputs.nixosConfigurations;
+
   hosts = pkgs.releaseTools.aggregate {
     name = "hosts";
-    constituents = mapAttrsToList getCfg outputs.nixosConfigurations;
+    constituents = machines;
   };
 }

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -4,13 +4,15 @@ let
   pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
+  hostToAgg = _: cfg: cfg;
 in
 rec {
   inherit (outputs) formatter devShells checks;
 
+  host = mapAttrs getCfg outputs.nixosConfigurations;
+
   hosts = pkgs.releaseTools.aggregate {
     name = "hosts";
-    constituents = mapAttrsToList getCfg outputs.nixosConfigurations;
+    constituents = mapAttrsToList hostToAgg host;
   };
 }
-// (mapAttrs getCfg outputs.nixosConfigurations)

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -1,10 +1,14 @@
 { inputs, outputs }:
 let
   inherit (inputs.nixpkgs.lib) mapAttrs;
+  pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
 in
 {
-  inherit (outputs) formatter devShells;
-  hosts = mapAttrs getCfg outputs.nixosConfigurations;
+  inherit (outputs) formatter devShells checks;
+  hosts = pkgs.releaseTools.aggregate {
+    name = "hosts";
+    constituents = mapAttrs getCfg outputs.nixosConfigurations;
+  };
 }

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -1,6 +1,6 @@
 { inputs, outputs }:
 let
-  inherit (inputs.nixpkgs.lib) mapAttrsToList;
+  inherit (inputs.nixpkgs.lib) mapAttrs mapAttrsToList;
   pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
@@ -8,10 +8,9 @@ in
 rec {
   inherit (outputs) formatter devShells checks;
 
-  machines = mapAttrsToList getCfg outputs.nixosConfigurations;
-
   hosts = pkgs.releaseTools.aggregate {
     name = "hosts";
-    constituents = machines;
+    constituents = mapAttrsToList getCfg outputs.nixosConfigurations;
   };
 }
+// (mapAttrs getCfg outputs.nixosConfigurations)

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -1,27 +1,45 @@
-{ inputs, outputs }:
+{
+  inputs,
+  outputs,
+  systems,
+}:
 let
-  inherit (inputs.nixpkgs.lib) mapAttrs mapAttrsToList;
+  inherit (inputs.nixpkgs) lib;
   pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
   hostToAgg = _: cfg: cfg;
+
+  # get per-system check derivation (with optional postfix)
+  mapSystems =
+    {
+      check,
+      postfix ? "",
+    }:
+    (map (system: if postfix == "" then check.${system} else check.${system}.${postfix}) systems);
 in
 rec {
   inherit (outputs) formatter devShells checks;
 
-  host = mapAttrs getCfg outputs.nixosConfigurations;
+  host = lib.mapAttrs getCfg outputs.nixosConfigurations;
 
   hosts = pkgs.releaseTools.aggregate {
     name = "hosts";
-    constituents = mapAttrsToList hostToAgg host;
+    constituents = lib.mapAttrsToList hostToAgg host;
   };
 
   devChecks = pkgs.releaseTools.aggregate {
     name = "devChecks";
-    constituents = [
-      formatter.x86_64-linux
-      devShells.x86_64-linux
-      checks.x86_64-linux
+    constituents = lib.flatten [
+      (mapSystems { check = formatter; })
+      (mapSystems {
+        check = checks;
+        postfix = "pre-commit-check";
+      })
+      (mapSystems {
+        check = devShells;
+        postfix = "default";
+      })
     ];
   };
 }

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -1,6 +1,6 @@
 { inputs, outputs }:
 let
-  inherit (inputs.nixpkgs.lib) mapAttrs;
+  inherit (inputs.nixpkgs.lib) mapAttrsToList;
   pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
 
   getCfg = _: cfg: cfg.config.system.build.toplevel;
@@ -9,6 +9,6 @@ in
   inherit (outputs) formatter devShells checks;
   hosts = pkgs.releaseTools.aggregate {
     name = "hosts";
-    constituents = mapAttrs getCfg outputs.nixosConfigurations;
+    constituents = mapAttrsToList getCfg outputs.nixosConfigurations;
   };
 }

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -15,4 +15,13 @@ rec {
     name = "hosts";
     constituents = mapAttrsToList hostToAgg host;
   };
+
+  devChecks = pkgs.releaseTools.aggregate {
+    name = "devChecks";
+    constituents = [
+      formatter
+      devShells
+      checks
+    ];
+  };
 }

--- a/hydra/jobs.nix
+++ b/hydra/jobs.nix
@@ -19,9 +19,9 @@ rec {
   devChecks = pkgs.releaseTools.aggregate {
     name = "devChecks";
     constituents = [
-      formatter
-      devShells
-      checks
+      formatter.x86_64-linux
+      devShells.x86_64-linux
+      checks.x86_64-linux
     ];
   };
 }

--- a/hydra/jobsets.nix
+++ b/hydra/jobsets.nix
@@ -1,10 +1,4 @@
-{
-  pulls,
-  branches,
-  nixexpr,
-  nixpkgs,
-  ...
-}:
+{ pulls, branches, ... }:
 let
   # create the json spec for the jobset
   makeSpec =
@@ -45,18 +39,9 @@ let
       enabled = 1;
       type = 1;
       hidden = false;
-      checkinterval = 300; # every 6 months
+      checkinterval = 300; # every 5 minutes
       enableemail = false;
       emailoverride = "";
-      inputs = {
-        inherit
-          nixexpr
-          nixpkgs
-          pulls
-          branches
-          ;
-        # rev = pkgs.runCommand "rev" {} ''echo "${src.rev}" > $out'';
-      };
     };
 
   # Create a hydra job for a branch

--- a/hydra/jobsets.nix
+++ b/hydra/jobsets.nix
@@ -19,7 +19,7 @@ let
 
   prs = readJSONFile pulls;
   refs = readJSONFile branches;
-  repo = "RAD-Development/nix-dotfiles";
+  repo = "ahuston-0/nix-dotfiles-hydra";
 
   # template for creating a job
   makeJob =

--- a/hydra/jobsets.nix
+++ b/hydra/jobsets.nix
@@ -1,4 +1,10 @@
-{ pulls, branches, ... }:
+{
+  pulls,
+  branches,
+  nixexpr,
+  nixpkgs,
+  ...
+}:
 let
   # create the json spec for the jobset
   makeSpec =
@@ -19,7 +25,7 @@ let
 
   prs = readJSONFile pulls;
   refs = readJSONFile branches;
-  repo = "ahuston-0/nix-dotfiles-hydra";
+  repo = "RAD-Development/nix-dotfiles";
 
   # template for creating a job
   makeJob =
@@ -42,6 +48,15 @@ let
       checkinterval = 300; # every 6 months
       enableemail = false;
       emailoverride = "";
+      inputs = {
+        inherit
+          nixexpr
+          nixpkgs
+          pulls
+          branches
+          ;
+        # rev = pkgs.runCommand "rev" {} ''echo "${src.rev}" > $out'';
+      };
     };
 
   # Create a hydra job for a branch

--- a/hydra/spec.json
+++ b/hydra/spec.json
@@ -12,7 +12,7 @@
   "type": 0,
   "inputs": {
     "nixexpr": {
-      "value": "https://github.com/RAD-Development/nix-dotfiles main",
+      "value": "https://github.com/ahuston-0/nix-dotfiles-hydra main",
       "type": "git",
       "emailresponsible": false
     },
@@ -23,12 +23,12 @@
     },
     "pulls": {
       "type": "githubpulls",
-      "value": "RAD-Development nix-dotfiles",
+      "value": "ahuston-0 nix-dotfiles-hydra",
       "emailresponsible": false
     },
     "branches": {
       "type": "github_refs",
-      "value": "RAD-Development nix-dotfiles heads -",
+      "value": "ahuston-0 nix-dotfiles-hydra heads -",
       "emailresponsible": false
     }
   }

--- a/hydra/spec.json
+++ b/hydra/spec.json
@@ -12,23 +12,23 @@
   "type": 0,
   "inputs": {
     "nixexpr": {
-      "value": "https://github.com/ahuston-0/nix-dotfiles-hydra main",
+      "value": "https://github.com/RAD-Development/nix-dotfiles main",
       "type": "git",
       "emailresponsible": false
     },
     "nixpkgs": {
-      "value": "https://github.com/NixOS/nixpkgs nixos-unstable-small",
+      "value": "https://github.com/NixOS/nixpkgs nixos-unstable",
       "type": "git",
       "emailresponsible": false
     },
     "pulls": {
       "type": "githubpulls",
-      "value": "ahuston-0 nix-dotfiles-hydra",
+      "value": "RAD-Development nix-dotfiles",
       "emailresponsible": false
     },
     "branches": {
       "type": "github_refs",
-      "value": "ahuston-0 nix-dotfiles-hydra heads -",
+      "value": "RAD-Development nix-dotfiles heads -",
       "emailresponsible": false
     }
   }

--- a/systems/palatine-hill/hydra.nix
+++ b/systems/palatine-hill/hydra.nix
@@ -43,7 +43,7 @@ in
   services = {
     hydra = {
       enable = true;
-      hydraURL = "http://localhost:3000";
+      hydraURL = "https://hydra.alicehuston.xyz";
       smtpHost = "alicehuston.xyz";
       notificationSender = "hydra@alicehuston.xyz";
       gcRootsDir = "/ZFS/ZFS-primary/hydra";
@@ -60,6 +60,7 @@ in
           ## This example will match all jobs
           #jobs = .*
           inputs = nixexpr
+          useShortContext = true
           excludeBuildFromContext = 1
         </githubstatus>
         Include ${config.sops.secrets."alice/gha-hydra-token".path}

--- a/systems/palatine-hill/hydra.nix
+++ b/systems/palatine-hill/hydra.nix
@@ -57,7 +57,16 @@ in
         </git-input>
         <githubstatus>
           # check hosts and any declared checks
-          jobs = (build-fork-hydra):pr-.*:(hosts|checks.*)
+          jobs = (build-fork-hydra):pr-.*:hosts
+          context = ci/hydra: hosts
+          inputs = nixexpr
+          useShortContext = true
+          excludeBuildFromContext = 1
+        </githubstatus>
+        <githubstatus>
+          # check hosts and any declared checks
+          jobs = (build-fork-hydra):pr-.*:devChecks
+          context = ci/hydra: checks
           inputs = nixexpr
           useShortContext = true
           excludeBuildFromContext = 1

--- a/systems/palatine-hill/hydra.nix
+++ b/systems/palatine-hill/hydra.nix
@@ -55,6 +55,13 @@ in
         <git-input>
           timeout = 3600
         </git-input>
+        <githubstatus>
+          jobs = build-fork-hydra:pr-.*:hosts\..*
+          ## This example will match all jobs
+          #jobs = .*
+          inputs = nixexpr
+          excludeBuildFromContext = 1
+        </githubstatus>
         Include ${config.sops.secrets."alice/gha-hydra-token".path}
         <hydra_notify>
           <prometheus>

--- a/systems/palatine-hill/hydra.nix
+++ b/systems/palatine-hill/hydra.nix
@@ -57,7 +57,7 @@ in
         </git-input>
         <githubstatus>
           # check hosts and any declared checks
-          jobs = (build-fork-hydra):pr-.*:hosts
+          jobs = (build-fork-hydra|nix-dotfiles-build):pr-.*:hosts
           context = ci/hydra: hosts
           inputs = nixexpr
           useShortContext = true
@@ -65,7 +65,7 @@ in
         </githubstatus>
         <githubstatus>
           # check hosts and any declared checks
-          jobs = (build-fork-hydra):pr-.*:devChecks
+          jobs = (build-fork-hydra|nix-dotfiles-build):pr-.*:devChecks
           context = ci/hydra: checks
           inputs = nixexpr
           useShortContext = true

--- a/systems/palatine-hill/hydra.nix
+++ b/systems/palatine-hill/hydra.nix
@@ -56,9 +56,8 @@ in
           timeout = 3600
         </git-input>
         <githubstatus>
-          jobs = build-fork-hydra:pr-.*:hosts\..*
-          ## This example will match all jobs
-          #jobs = .*
+          # check hosts and any declared checks
+          jobs = (build-fork-hydra):pr-.*:(hosts|checks.*)
           inputs = nixexpr
           useShortContext = true
           excludeBuildFromContext = 1


### PR DESCRIPTION
This allows Hydra checks to report back to GitHub, and adds aggregate checks so the checks have a consistent schema for enabling check verification for PRs.

Part 2 of this will include disabling the nix-flake-check and formatting GitHub action. 