### PR TITLE
allow temporarily disabling pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # direnv
 .direnv
 .envrc
+.noprecommit
 
 # build outputs
 .*.swp

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,6 +14,11 @@ Please install `direnv` and run `direnv allow` in the project directory to
 add the pre-commit-hooks to your workflow. We will reject PRs if we notice
 violations in the pre-commit checks.
 
+To disable pre-commit hooks from your shell, run `touch .noprecommit` in the
+top-level of the repo. This will not stop the checks from running during the PR
+checks, but will prevent them from running in the direnv environment when
+inconvenient.
+
 ## Active Development
 
 To contribute to the repo, you can either ask to have a role (for those who are

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,18 @@ forEachSystem (
 
     # construct the shell provided by pre-commit for running hooks
     pre-commit = pkgs.mkShell {
-      inherit (checks.${system}.pre-commit-check) shellHook;
+      shellHook = ''
+        if [ -f ./.noprecommit ]; then
+          echo ".noprecommit found! Delete this file to re-install pre-commit hooks"
+          if [ -f ./.pre-commit-config.yaml ]; then
+            echo "uninstalling pre-commit hooks"
+            pre-commit uninstall
+            rm .pre-commit-config.yaml
+          fi
+        else
+          ${checks.${system}.pre-commit-check.shellHook}
+        fi
+      '';
       buildInputs = checks.${system}.pre-commit-check.enabledPackages;
     };
 


### PR DESCRIPTION
Adds the ability to disable pre-commit-hooks by running `touch .noprecommit`, as well as updating the relevant docs