### PR TITLE
removes cinnamon namespace from packages, as per recent nix warning.

### DIFF
--- a/systems/artemision/programs.nix
+++ b/systems/artemision/programs.nix
@@ -12,7 +12,7 @@
     calibre
     # calibre dedrm?
     candy-icons
-    cinnamon.nemo-with-extensions
+    nemo-with-extensions
     croc
     deadnix
     direnv

--- a/users/richie/home/gui/default.nix
+++ b/users/richie/home/gui/default.nix
@@ -8,8 +8,8 @@
   home.packages = with pkgs; [
     beeper
     candy-icons
-    cinnamon.nemo
-    cinnamon.nemo-fileroller
+    nemo
+    nemo-fileroller
     discord-canary
     gimp
     gparted


### PR DESCRIPTION
Closes #274